### PR TITLE
Merge from dev (bugfix + upgrades)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.sw?
 *.gem
 *.rbc
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,15 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rake', '~> 10.0'
-  gem 'cucumber', '~> 1.3'
-  gem 'aruba', '~> 0.5'
+  gem 'aruba', '~> 0.7.4'
+  gem 'capybara', '~> 2.5.0'
+  gem 'codeclimate-test-reporter', '~> 0.3'
+  gem 'coveralls', '~> 0.8'
+  gem 'cucumber', '~> 2.0'
   gem 'fivemat'
-  gem 'codeclimate-test-reporter'
+  gem 'rake', '~> 10.0'
+  gem 'rspec', '~> 3.0'
+  gem 'rubocop', '~> 0.24'
+  gem 'simplecov', '~> 0.10'
 end
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,8 +1,14 @@
-PROJECT_ROOT_PATH = File.dirname(File.dirname(File.dirname(__FILE__)))
+ENV["TEST"] = "true"
+
 require 'middleman-core'
 require 'middleman-core/step_definitions'
 
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.root(File.expand_path(File.dirname(__FILE__) + '/../..'))
+SimpleCov.start
 
+require 'coveralls'
+Coveralls.wear!
+
+PROJECT_ROOT_PATH = File.dirname(File.dirname(File.dirname(__FILE__)))
 require File.join(PROJECT_ROOT_PATH, 'lib', 'middleman-deploy')

--- a/lib/middleman-deploy/methods/ftp.rb
+++ b/lib/middleman-deploy/methods/ftp.rb
@@ -1,5 +1,4 @@
 require 'net/ftp'
-require 'ptools'
 
 module Middleman
   module Deploy
@@ -48,11 +47,7 @@ module Middleman
           err_code  = reply[0, 3].to_i
 
           if err_code == 550
-            if File.binary?(filename)
-              ftp.putbinaryfile(filename, filename)
-            else
-              ftp.puttextfile(filename, filename)
-            end
+            ftp.putbinaryfile(filename, filename)
           end
         end
 

--- a/lib/middleman-deploy/methods/sftp.rb
+++ b/lib/middleman-deploy/methods/sftp.rb
@@ -1,5 +1,4 @@
 require 'net/sftp'
-require 'ptools'
 
 module Middleman
   module Deploy

--- a/lib/middleman-deploy/pkg-info.rb
+++ b/lib/middleman-deploy/pkg-info.rb
@@ -1,7 +1,7 @@
 module Middleman
   module Deploy
     PACKAGE = 'middleman-deploy'
-    VERSION = '2.0.0-alpha'
+    VERSION = '2.0.1-alpha'
     TAGLINE = 'Deploy a middleman built site over rsync, ftp, sftp, or git (e.g. gh-pages on github).'
     README = %{
 You should follow one of the four examples below to setup the deploy

--- a/middleman-deploy.gemspec
+++ b/middleman-deploy.gemspec
@@ -17,16 +17,17 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.5'
 
-  spec.add_dependency 'middleman-core', '>= 3.2'
-  spec.add_dependency 'ptools'
+  spec.add_dependency 'middleman-cli', '~> 4.3.0'
+  spec.add_dependency 'middleman-core', '~> 4.3.0'
+
   spec.add_dependency 'net-sftp'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'kramdown', '>= 0.14'
-  spec.add_development_dependency 'rubocop', '~> 0.19'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'kramdown', '~> 1.2'
+  spec.add_development_dependency 'rubocop', '~> 0.24'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Stop using ptools (and by extension, its dependency win32-file) because
they fundamentally break how the Pathname gem (part of the stdlib since
at least 1.8.7) work.  Since middleman heavily relies on Pathname (cf.
at least middleman-core/Sources and SourceWatcher), this causes subtle
and difficult to debug breaks on Windows boxes.

The only usage of ptools in the code was the monkey patched version of
File.binary? that it provided (by the FTP/STFP deploy methods) ... the
code has been modified to always assume binary now.  I think this is a
safe assumption in 2019.

It should be noted that the provided version of File.binary? was only at
[best probablistic](https://github.com/djberg96/ptools/blob/8d1390b057652ffde310fc8971615f0f3daf2393/lib/ptools.rb#L94)
... it looked at all the file characters and determined what percentage
were non-ASCII.

Without this fix, on Windows 10 I observed a failure with an error like:

    no implicit conversion from nil to integer (TypeError)
    C:/Ruby25-x64/lib/ruby/2.5.0/pathname.rb:46:in `[]'
    C:/Ruby25-x64/lib/ruby/2.5.0/pathname.rb:46:in `chop_basename'
    C:/Ruby25-x64/lib/ruby/2.5.0/pathname.rb:511:in `relative_path_from'
    C:/Ruby25-x64/lib/ruby/gems/2.5.0/bundler/gems/middleman-bb8faf01d230/middleman-core/lib/middleman-core/sources/source_watcher.rb:235:in `should_not_recurse?'
    C:/Ruby25-x64/lib/ruby/gems/2.5.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
    C:/Ruby25-x64/lib/ruby/gems/2.5.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
    C:/Ruby25-x64/lib/ruby/gems/2.5.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
    ...

Here is how to reproduce the win32-file brokenness directly in irb on Windows:

    irb> require 'pathname'
    => true
    irb> p = Pathname.new('c:/')
    => #<Pathname:c:/>
    irb> p.cleanpath.to_s
    => "c:/"
    irb> require 'win32-file'
    => true
    irb> p.cleanpath.to_s
    => "c:\\"

Other changes:

* Update dependencies to use new bundler, etc. and cleanup.
* Update to use simplecov
* Point to cwboyd/middleman because it has a fix for Padrino...Tags needing to be explicitly required.
* Cleanup env.rb for the test fixture.
* middleman seems to want a data subdirectory
* bump version
